### PR TITLE
Show progess when running `make check`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,4 +22,4 @@ jobs:
     - name: make
       run: make
     - name: make check
-      run: ./tests
+      run: make check

--- a/test/tests.c
+++ b/test/tests.c
@@ -35,15 +35,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include "trace_debugger.h"
-/* #include "trace_debugger.c" */
 #include "disassembly.h"
-/* #include "disassembly.c" */
 #include "utils.h"
-/* #include "utils.c" */
 #include "serialize.h"
 #include "workaround.h"
-/* #include "serialize.c" */
-/* #include "error.c" */
 
 #define TRDB_SUCCESS 0
 #define TRDB_FAIL -1
@@ -1244,8 +1239,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         arguments->args[state->arg_num] = arg;
         break;
     case ARGP_KEY_END:
-	/* We allow passing no positional argument. This will just run the basic
-	 * tests */
+        /* We allow passing no positional argument. This will just run the basic
+         * tests */
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -1418,7 +1413,9 @@ int main(int argc, char *argv[argc + 1])
         if (access(stim, R_OK)) {
             LOG_ERRT("File not found, skipping test at %s\n", stim);
             if (trs_fp)
-                fprintf(trs_fp, ":test-result: SKIP test_compress_cvs_trace(%s)\n", stim);
+                fprintf(trs_fp,
+                        ":test-result: SKIP test_compress_cvs_trace(%s)\n",
+                        stim);
             continue;
         }
         RUN_TEST(test_compress_cvs_trace, stim);
@@ -1435,10 +1432,17 @@ int main(int argc, char *argv[argc + 1])
         if (access(bin, R_OK) || access(stim, R_OK)) {
             LOG_ERRT("File not found, skipping test at %s\n", bin);
             if (trs_fp) {
-                fprintf(trs_fp, ":test-result: SKIP test_compress_trace(%s)\n", bin);
-                fprintf(trs_fp, ":test-result: SKIP test_compress_trace_differential(%s, true, false)\n", bin);
-                fprintf(trs_fp, ":test-result: SKIP test_compress_trace_differential(%s, true, true)\n", bin);
-	    }
+                fprintf(trs_fp, ":test-result: SKIP test_compress_trace(%s)\n",
+                        bin);
+                fprintf(
+                    trs_fp,
+                    ":test-result: SKIP test_compress_trace_differential(%s, true, false)\n",
+                    bin);
+                fprintf(
+                    trs_fp,
+                    ":test-result: SKIP test_compress_trace_differential(%s, true, true)\n",
+                    bin);
+            }
             continue;
         }
         RUN_TEST(test_decompress_trace, bin, stim);

--- a/test/tests.c
+++ b/test/tests.c
@@ -1358,9 +1358,9 @@ int main(int argc, char *argv[argc + 1])
                 perror("dup2");
                 exit(EXIT_FAILURE);
             }
-            /* disable output buffering so that we can tail logs efficienctly as
+            /* enable line buffering so that we can tail logs efficienctly as
              * for redirect output buffers are not flushed on a newline */
-            setbuf(log_fp, NULL);
+            setlinebuf(log_fp);
         }
     }
 
@@ -1377,9 +1377,9 @@ int main(int argc, char *argv[argc + 1])
                 perror("fopen");
                 exit(EXIT_FAILURE);
             }
-            /* disable output buffering so that we can tail logs efficienctly as
+            /* enable line buffering so that we can tail logs efficienctly as
              * for redirect output buffers are not flushed on a newline */
-            setbuf(trs_fp, NULL);
+            setlinebuf(trs_fp);
         }
     }
 

--- a/test/tests.c
+++ b/test/tests.c
@@ -1473,11 +1473,11 @@ int main(int argc, char *argv[argc + 1])
     if (TESTS_SUCCESSFULL()) {
         printf("ALL TESTS PASSED\n");
         if (trs_fp)
-            fprintf(trs_fp, ":test-global-result: PASS");
+            fprintf(trs_fp, ":test-global-result: PASS\n");
     } else {
         printf("AT LEAST ONE TEST FAILED\n");
         if (trs_fp)
-            fprintf(trs_fp, ":test-global-result: FAIL");
+            fprintf(trs_fp, ":test-global-result: FAIL\n");
     }
 
     if (log_fp)


### PR DESCRIPTION
We now redirect printf to both stdout and the given log file so one can now follow the testing progress in the terminal.